### PR TITLE
Fixed Cyprus dial code

### DIFF
--- a/data/countries.json
+++ b/data/countries.json
@@ -252,7 +252,7 @@
   {
     "name": "Cyprus",
     "code": "cy",
-    "dial_code": "+537"
+    "dial_code": "+357"
   },
   {
     "name": "Czech Republic",


### PR DESCRIPTION
Changed [Cyprus dial_code](https://en.wikipedia.org/wiki/Telephone_numbers_in_Cyprus) from "+537" to "+357".