### PR TITLE
fix(state): fix the terengganu typo

### DIFF
--- a/src/data/states.ts
+++ b/src/data/states.ts
@@ -2031,7 +2031,7 @@ const states: any = {
     'Sabah',
     'Sarawak',
     'Selangor',
-    'Terenggan',
+    'Terengganu',
   ],
   mv: [
     'Alifu Atholh',


### PR DESCRIPTION
I found out that terengganu is spelt as terenggan

https://github.com/AnupKumarPanwar/country-state-picker/blob/master/src/data/states.ts#L2034